### PR TITLE
chore!: use import.meta.dirname

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,3 @@
 #!/usr/bin/env node
-import {fileURLToPath} from 'node:url';
-import path from 'node:path';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-console.log(__dirname);
+console.log(import.meta.dirname);

--- a/test.js
+++ b/test.js
@@ -3,5 +3,5 @@ import execa from 'execa';
 
 test('main', async t => {
 	const {stdout} = await execa('./cli.js');
-	t.true(stdout.length > 0);
+	t.true(stdout.length > 0 && stdout !== 'undefined');
 });


### PR DESCRIPTION
Use [`import.meta.dirname`](https://nodejs.org/docs/latest/api/esm.html#importmetadirname), but we need to drop Node.js with version under 22 (or 20, but **experimental**).
